### PR TITLE
Rename palette functions for consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,14 +36,14 @@ class scale_color_npg(scale_discrete):
 
     def __post_init__(self, palette, alpha):
         super().__post_init__()
-        self.palette = npg_pal(palette, alpha)
+        self.palette = pal_npg(palette, alpha)
 ```
 
 **Continuous scales**: Use functions that return `scale_*_gradientn`
 
 ```python
 def scale_color_gsea(palette="default", alpha=1.0, reverse=False, **kwargs):
-    colors = gsea_pal(palette, n=512, alpha=alpha, reverse=reverse)
+    colors = pal_gsea(palette, n=512, alpha=alpha, reverse=reverse)
     return scale_color_gradientn(colors=colors, **kwargs)
 ```
 
@@ -107,7 +107,7 @@ from ggsci import (
     scale_color_flatui,                     # Discrete FlatUI
     scale_color_gsea, scale_fill_gsea,      # Continuous diverging
     scale_color_bs5, scale_fill_bs5,        # Continuous sequential
-    npg_pal, flatui_pal, gsea_pal, bs5_pal  # Palette functions
+    pal_npg, pal_flatui, pal_gsea, pal_bs5  # Palette functions
 )
 ```
 

--- a/src/ggsci/__init__.py
+++ b/src/ggsci/__init__.py
@@ -5,7 +5,7 @@ A Python implementation of the R ggsci package, providing color palettes
 inspired by scientific journals and sci-fi themes.
 """
 
-from .palettes import bs5_pal, flatui_pal, gsea_pal, npg_pal
+from .palettes import pal_bs5, pal_flatui, pal_gsea, pal_npg
 from .scales import (
     scale_color_bs5,
     scale_color_flatui,
@@ -36,8 +36,8 @@ __all__ = [
     "scale_color_bs5",
     "scale_fill_bs5",
     "scale_colour_bs5",
-    "npg_pal",
-    "flatui_pal",
-    "gsea_pal",
-    "bs5_pal",
+    "pal_npg",
+    "pal_flatui",
+    "pal_gsea",
+    "pal_bs5",
 ]

--- a/src/ggsci/palettes.py
+++ b/src/ggsci/palettes.py
@@ -11,7 +11,7 @@ from .data import PALETTES
 from .utils import apply_alpha, interpolate_colors
 
 
-def npg_pal(palette: str = "nrc", alpha: float = 1.0) -> Callable[[int], List[str]]:
+def pal_npg(palette: str = "nrc", alpha: float = 1.0) -> Callable[[int], List[str]]:
     """
     NPG journal color palette
 
@@ -49,7 +49,7 @@ def npg_pal(palette: str = "nrc", alpha: float = 1.0) -> Callable[[int], List[st
     return palette_func
 
 
-def flatui_pal(
+def pal_flatui(
     palette: str = "default", alpha: float = 1.0
 ) -> Callable[[int], List[str]]:
     """
@@ -89,7 +89,7 @@ def flatui_pal(
     return palette_func
 
 
-def gsea_pal(
+def pal_gsea(
     palette: str = "default",
     n: int = 12,
     alpha: float = 1.0,
@@ -132,7 +132,7 @@ def gsea_pal(
     return colors
 
 
-def bs5_pal(
+def pal_bs5(
     palette: str = "blue",
     n: int = 10,
     alpha: float = 1.0,

--- a/src/ggsci/scales.py
+++ b/src/ggsci/scales.py
@@ -8,7 +8,7 @@ from typing import Literal
 from plotnine.scales import scale_color_gradientn, scale_fill_gradientn
 from plotnine.scales.scale_discrete import scale_discrete
 
-from .palettes import bs5_pal, flatui_pal, gsea_pal, npg_pal
+from .palettes import pal_bs5, pal_flatui, pal_gsea, pal_npg
 
 
 # NPG scales (discrete, no variation)
@@ -32,7 +32,7 @@ class scale_color_npg(scale_discrete):
 
     def __post_init__(self, palette, alpha):
         super().__post_init__()
-        self.palette = npg_pal(palette, alpha)
+        self.palette = pal_npg(palette, alpha)
 
 
 @dataclass
@@ -55,7 +55,7 @@ class scale_fill_npg(scale_discrete):
 
     def __post_init__(self, palette, alpha):
         super().__post_init__()
-        self.palette = npg_pal(palette, alpha)
+        self.palette = pal_npg(palette, alpha)
 
 
 # FlatUI scales (discrete with 3 variations)
@@ -79,7 +79,7 @@ class scale_color_flatui(scale_discrete):
 
     def __post_init__(self, palette, alpha):
         super().__post_init__()
-        self.palette = flatui_pal(palette, alpha)
+        self.palette = pal_flatui(palette, alpha)
 
 
 @dataclass
@@ -102,7 +102,7 @@ class scale_fill_flatui(scale_discrete):
 
     def __post_init__(self, palette, alpha):
         super().__post_init__()
-        self.palette = flatui_pal(palette, alpha)
+        self.palette = pal_flatui(palette, alpha)
 
 
 # GSEA scales (continuous diverging)
@@ -121,7 +121,7 @@ def scale_color_gsea(palette="default", alpha=1.0, reverse=False, **kwargs):
     **kwargs
         Additional arguments passed to plotnine.scale_color_gradientn.
     """
-    colors = gsea_pal(palette, n=512, alpha=alpha, reverse=reverse)
+    colors = pal_gsea(palette, n=512, alpha=alpha, reverse=reverse)
     return scale_color_gradientn(colors=colors, **kwargs)
 
 
@@ -140,7 +140,7 @@ def scale_fill_gsea(palette="default", alpha=1.0, reverse=False, **kwargs):
     **kwargs
         Additional arguments passed to plotnine.scale_fill_gradientn.
     """
-    colors = gsea_pal(palette, n=512, alpha=alpha, reverse=reverse)
+    colors = pal_gsea(palette, n=512, alpha=alpha, reverse=reverse)
     return scale_fill_gradientn(colors=colors, **kwargs)
 
 
@@ -161,7 +161,7 @@ def scale_color_bs5(palette="blue", alpha=1.0, reverse=False, **kwargs):
     **kwargs
         Additional arguments passed to plotnine.scale_color_gradientn.
     """
-    colors = bs5_pal(palette, n=512, alpha=alpha, reverse=reverse)
+    colors = pal_bs5(palette, n=512, alpha=alpha, reverse=reverse)
     return scale_color_gradientn(colors=colors, **kwargs)
 
 
@@ -181,7 +181,7 @@ def scale_fill_bs5(palette="blue", alpha=1.0, reverse=False, **kwargs):
     **kwargs
         Additional arguments passed to plotnine.scale_fill_gradientn.
     """
-    colors = bs5_pal(palette, n=512, alpha=alpha, reverse=reverse)
+    colors = pal_bs5(palette, n=512, alpha=alpha, reverse=reverse)
     return scale_fill_gradientn(colors=colors, **kwargs)
 
 


### PR DESCRIPTION
This PR renames the palette functions from `*_pal()` (mizani) to `pal_*()` (r-ggsci).

This makes the naming scheme 100% consistent with the R package.