### PR TITLE
Add example plot functions and align plot appearance

### DIFF
--- a/docs/articles/get-started.md
+++ b/docs/articles/get-started.md
@@ -32,16 +32,8 @@ from plotnine import (
     aes,
     element_blank,
     element_rect,
-    element_text,
-    geom_bar,
-    geom_boxplot,
-    geom_histogram,
-    geom_point,
-    geom_smooth,
     geom_tile,
     ggplot,
-    labs,
-    position_dodge,
     scale_fill_identity,
     scale_x_continuous,
     scale_y_continuous,
@@ -82,24 +74,15 @@ LAST = None
 
 ## Discrete color palettes
 
-We will use a scatter plot with smoothed curves and a bar plot to demonstrate
-discrete palettes. The examples below use the `diamonds` dataset and apply
-each palette to `color` and `fill` scales respectively.
+We will use reusable helpers that construct a scatter plot with a smoothed
+curve and a side-by-side bar plot to demonstrate discrete palettes. The
+examples below use the `diamonds` dataset and apply each palette to `color`
+and `fill` scales respectively.
 
 ```python exec="on" source="above" session="default"
 # Base plots shared for discrete palette demos
-p1 = (
-    ggplot(diamonds.query("carat >= 2.2"), aes("table", "price", color="cut"))
-    + geom_point(alpha=0.7)
-    + geom_smooth(method="lm", alpha=0.05, size=1)
-    + theme_bw()
-)
-
-p2 = (
-    ggplot(diamonds, aes("color", fill="cut"))
-    + geom_bar(position=position_dodge())
-    + theme_bw()
-)
+p1 = example_scatterplot()
+p2 = example_barplot()
 ```
 
 ### NPG

--- a/src/ggsci/__init__.py
+++ b/src/ggsci/__init__.py
@@ -2,6 +2,7 @@
 Scientific journal and sci-fi themed color palettes for plotnine.
 """
 
+from .examples import example_barplot, example_scatterplot
 from .palettes import (
     pal_aaas,
     pal_bmj,

--- a/src/ggsci/examples.py
+++ b/src/ggsci/examples.py
@@ -1,0 +1,72 @@
+"""
+Example plots used in documentation and demos.
+"""
+
+from __future__ import annotations
+
+from plotnine import (
+    aes,
+    element_blank,
+    geom_bar,
+    geom_point,
+    geom_smooth,
+    ggplot,
+    position_dodge,
+    theme,
+    theme_minimal,
+)
+from plotnine.data import diamonds
+
+
+def example_scatterplot() -> ggplot:
+    """
+    Create the scatter plot example used in documentation.
+
+    Args:
+        None.
+
+    Returns:
+        Plot configured for discrete color palette demonstrations.
+
+    Raises:
+        None.
+    """
+    large_diamonds = diamonds.loc[diamonds["carat"] >= 2.2]
+
+    return (
+        ggplot(large_diamonds, aes("table", "price", color="cut"))
+        + geom_point(alpha=0.7)
+        + geom_smooth(method="lm", alpha=0.05, size=1)
+        + theme_minimal()
+        + theme(
+            axis_title_x=element_blank(),
+            axis_title_y=element_blank(),
+            panel_grid_minor=element_blank(),
+        )
+    )
+
+
+def example_barplot() -> ggplot:
+    """
+    Create the bar plot example used in documentation.
+
+    Args:
+        None.
+
+    Returns:
+        Plot configured for discrete fill palette demonstrations.
+
+    Raises:
+        None.
+    """
+    return (
+        ggplot(diamonds, aes("color", fill="cut"))
+        + geom_bar(position=position_dodge())
+        + theme_minimal()
+        + theme(
+            axis_title_x=element_blank(),
+            axis_title_y=element_blank(),
+            panel_grid_major_x=element_blank(),
+            panel_grid_minor_y=element_blank(),
+        )
+    )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,35 @@
+from collections.abc import Mapping, Sequence
+from typing import cast
+
+from plotnine.data import diamonds
+from plotnine.geoms import geom_bar, geom_point, geom_smooth
+from plotnine.ggplot import ggplot
+
+from ggsci import example_barplot, example_scatterplot
+
+
+def test_example_scatterplot_configuration() -> None:
+    plot = example_scatterplot()
+
+    assert isinstance(plot, ggplot)
+    assert len(plot.layers) == 2
+    assert plot.mapping["color"] == "cut"
+    assert plot.mapping["x"] == "table"
+    assert plot.mapping["y"] == "price"
+
+    data = cast(Mapping[str, Sequence[float]], plot.data)
+    carat = cast(Sequence[float], data["carat"])
+    assert all(value >= 2.2 for value in carat)
+    assert isinstance(plot.layers[0].geom, geom_point)
+    assert isinstance(plot.layers[1].geom, geom_smooth)
+
+
+def test_example_barplot_configuration() -> None:
+    plot = example_barplot()
+
+    assert isinstance(plot, ggplot)
+    assert plot.data is diamonds
+    assert plot.mapping["x"] == "color"
+    assert plot.mapping["fill"] == "cut"
+    assert len(plot.layers) == 1
+    assert isinstance(plot.layers[0].geom, geom_bar)


### PR DESCRIPTION
Closes #21 
Closes #22 

This PR adds two reusable example plot functions `example_barplot()` and `example_scatterplot()` and uses them in documentation, with graphical appearance aligned with the current r-ggsci examples. Tests are also added.