### PR TITLE
Release py-ggsci 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## py-ggsci 2.1.0
+
+### Improvements
+
+- Synchronized iTerm color palettes with upstream (#66).
+
+  This update added 66 new palettes to `ITERM_PALETTES`:
+  Aardvark Ink, Atlas Ragnarok, Aura Dark, base16-icy, cyberpunk-icy,
+  Claude variations, Clear variations, Cool Night, Electron Highlighter Day,
+  Emerald Synth, Everforest variations, Gleam variations, JetCalm Light,
+  Karasu variations, Karma variations, Keys Ocean Sunset variations,
+  Klein Void, London variations, Mesila One, Monokai SublimeText, Moonwalk,
+  Neon Purple, Oxide, Patina variations, Sandstone variations, Sauber,
+  Sequoia variations, Serendipity variations, Shokunin, Squintless,
+  Sumi variations, Token variations, and Trapped in Amber. These palettes are
+  now usable by `pal_iterm()`, `scale_color_iterm()`, and `scale_fill_iterm()`.
+
+  Additionally, the color values for Adwaita, the Catppuccin palettes
+  (Frappe, Latte, Macchiato, Mocha), and Electron Highlighter have been
+  updated to match the latest upstream color specifications.
+
 ## py-ggsci 2.0.0
 
 ### New features

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## py-ggsci 2.1.0
+
+### Improvements
+
+- Synchronized iTerm color palettes with upstream (#66).
+
+  This update added 66 new palettes to `ITERM_PALETTES`:
+  Aardvark Ink, Atlas Ragnarok, Aura Dark, base16-icy, cyberpunk-icy,
+  Claude variations, Clear variations, Cool Night, Electron Highlighter Day,
+  Emerald Synth, Everforest variations, Gleam variations, JetCalm Light,
+  Karasu variations, Karma variations, Keys Ocean Sunset variations,
+  Klein Void, London variations, Mesila One, Monokai SublimeText, Moonwalk,
+  Neon Purple, Oxide, Patina variations, Sandstone variations, Sauber,
+  Sequoia variations, Serendipity variations, Shokunin, Squintless,
+  Sumi variations, Token variations, and Trapped in Amber. These palettes are
+  now usable by `pal_iterm()`, `scale_color_iterm()`, and `scale_fill_iterm()`.
+
+  Additionally, the color values for Adwaita, the Catppuccin palettes
+  (Frappe, Latte, Macchiato, Mocha), and Electron Highlighter have been
+  updated to match the latest upstream color specifications.
+
 ## py-ggsci 2.0.0
 
 ### New features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ggsci"
-version = "2.0.0"
+version = "2.1.0"
 description = "Plotnine color palettes inspired by plots in scientific journals, data visualization libraries, science fiction movies, and TV shows"
 authors = [{ name = "Nan Xiao", email = "me@nanx.me" }]
 dependencies = ["matplotlib>=3.8.0", "numpy>=1.23.5", "plotnine>=0.14.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -431,7 +431,7 @@ wheels = [
 
 [[package]]
 name = "ggsci"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
This PR updates the changelog and bumps the version number.